### PR TITLE
fix: tsconfig `compilerOptions` made optional in projen

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -31,7 +31,7 @@ project.gitignore.exclude('.vscode/');
 // required for esbuild > v0.14.32
 // see https://github.com/evanw/esbuild/pull/2155
 // see https://stackoverflow.com/questions/56906718/error-ts2304-cannot-find-name-webassembly
-project.tsconfig?.compilerOptions.lib?.push('dom');
+project.tsconfig?.compilerOptions?.lib?.push('dom');
 
 // needed for CLI tests to run
 project.testTask.prependSpawn(project.compileTask);


### PR DESCRIPTION
This change is made due to change made in [Projen](https://github.com/projen) to make TSConfig `compilerOptions` optional [PR](https://github.com/projen/projen/pull/3436) causing issues on upgrading dev dependencies(`npx projen upgrade-dev-deps`).