### PR TITLE
fix: preserve symbol names in bundles

### DIFF
--- a/src/api/bundle.ts
+++ b/src/api/bundle.ts
@@ -115,6 +115,17 @@ export interface BundleProps {
   readonly minifySyntax?: boolean;
 
   /**
+   * Always keep the original value of the `name` property.
+   * Minification renames symbols to reduce code size and bundling sometimes need to rename symbols to avoid collisions.
+   * This option allows to preserve the original name values even in minified code.
+   *
+   * @see https://esbuild.github.io/api/#keep-names
+   *
+   * @default true
+   */
+  readonly keepNames?: boolean;
+
+  /**
    * Write the metafile into this location.
    *
    * @default - no metafile is written
@@ -199,6 +210,7 @@ export class Bundle {
   private readonly minifyWhitespace?: boolean;
   private readonly minifyIdentifiers?: boolean;
   private readonly minifySyntax?: boolean;
+  private readonly keepNames?: boolean;
   private readonly metafile?: string;
 
   private _bundle?: esbuild.BuildResult;
@@ -222,6 +234,7 @@ export class Bundle {
     this.minifyWhitespace = props.minifyWhitespace;
     this.minifyIdentifiers = props.minifyIdentifiers;
     this.minifySyntax = props.minifySyntax;
+    this.keepNames = props.keepNames ?? true;
     this.metafile = props.metafile;
 
     const entryPoints = props.entryPoints ?? (this.manifest.main ? [this.manifest.main] : []);
@@ -451,6 +464,7 @@ export class Bundle {
       minifyWhitespace: this.minifyWhitespace,
       minifyIdentifiers: this.minifyIdentifiers,
       minifySyntax: this.minifySyntax,
+      keepNames: this.keepNames,
       treeShaking: true,
       absWorkingDir: this.packageDir,
       external: [...(this.externals.dependencies ?? []), ...(this.externals.optionalDependencies ?? [])],


### PR DESCRIPTION
This PR enables the `keepNames` option on the Bundle API to allow preserving original symbol names during bundling. 
I default to it and did not make it an option on the CLI as I don't really see a downside to it.
See: https://esbuild.github.io/api/#keep-names

It solves the problem of class names being incorrectly named when bundled and printed as logs in some situations (mostly error classes).

### Before

<img width="1108" height="38" alt="image" src="https://github.com/user-attachments/assets/3eb932b6-41ff-4d01-a34f-c3eda673cf03" />

Note the `_ToolkitError` with incorrect underscore.

### After

<img width="1103" height="62" alt="image" src="https://github.com/user-attachments/assets/46b56a33-8d1b-4283-bdaa-43d4036422d0" />

Note the `AssemblyError` without underscore. The switch to Assembly from Toolkit is incidental to me being lazy to get a like for like screenshot.
